### PR TITLE
Add Git build fingerprinting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ logs/
 
 # Folder that has CTRE Phoenix Sim device config storage
 ctre_sim/
+
+# Build Constants for Git information
+src/main/java/frc/robot/BuildConstants.java

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2025.3.1"
     id 'com.diffplug.spotless' version '7.0.2'
+    id "com.peterabeles.gversion" version "1.10.2"
 }
 
 java {
@@ -107,6 +108,48 @@ wpi.java.configureTestTasks(test)
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
+}
+// Create commit with working changes on event branches
+task(eventDeploy) {
+    doLast {
+        if (project.gradle.startParameter.taskNames.any({ it.toLowerCase().contains("deploy") })) {
+            def branchPrefix = "event"
+            def branch = 'git branch --show-current'.execute().text.trim()
+            def commitMessage = "Update at '${new Date().toString()}'"
+
+            if (branch.startsWith(branchPrefix)) {
+                exec {
+                    workingDir(projectDir)
+                    executable 'git'
+                    args 'add', '-A'
+                }
+                exec {
+                    workingDir(projectDir)
+                    executable 'git'
+                    args 'commit', '-m', commitMessage
+                    ignoreExitValue = true
+                }
+
+                println "Committed to branch: '$branch'"
+                println "Commit message: '$commitMessage'"
+            } else {
+                println "Not on an event branch, skipping commit"
+            }
+        } else {
+            println "Not running deploy task, skipping commit"
+        }
+    }
+}
+createVersionFile.dependsOn(eventDeploy)
+
+project.compileJava.dependsOn(createVersionFile)
+gversion {
+    srcDir       = "src/main/java/"
+    classPackage = "frc.robot"
+    className    = "BuildConstants"
+    dateFormat   = "yyyy-MM-dd HH:mm:ss z"
+    timeZone     = "America/Chicago" // Use preferred time zone
+    indent       = "  "
 }
 
 compileJava.dependsOn 'spotlessApply'

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -50,7 +50,7 @@ public class RobotContainer {
       Alerts.gitDirtyAlert.set(true);
     }
 
-    if (BuildConstants.GIT_BRANCH != "main") {
+    if (BuildConstants.GIT_BRANCH.equals("main")) {
       if (BuildConstants.GIT_BRANCH.contains("event/")) {
         Alerts.gitEventBranchAlert.set(true);
       } else {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.commands.AlgaeCommand;
 import frc.robot.commands.ShooterCommand;
+import frc.robot.misc.Alerts;
 import frc.robot.subsystems.Algae;
 import frc.robot.subsystems.Shooter;
 
@@ -44,6 +45,18 @@ public class RobotContainer {
         "StopShooter", new InstantCommand(() -> shooter.disableShooter()));
 
     configureBindings();
+
+    if (BuildConstants.DIRTY == 1) {
+      Alerts.gitDirtyAlert.set(true);
+    }
+
+    if (BuildConstants.GIT_BRANCH != "main") {
+      if (BuildConstants.GIT_BRANCH.contains("event/")) {
+        Alerts.gitEventBranchAlert.set(true);
+      } else {
+        Alerts.gitMainBranchAlert.set(true);
+      }
+    }
   }
 
   /**

--- a/src/main/java/frc/robot/misc/Alerts.java
+++ b/src/main/java/frc/robot/misc/Alerts.java
@@ -1,0 +1,24 @@
+package frc.robot.misc;
+
+import edu.wpi.first.wpilibj.Alert;
+import edu.wpi.first.wpilibj.Alert.AlertType;
+
+public class Alerts {
+  // Git alert for when there are uncommitted changes in the repo
+  public static Alert gitDirtyAlert =
+      new Alert(
+          "There are uncommitted changes made to the repository! Please create a commit with all changes as soon as possible!",
+          AlertType.kWarning);
+
+  // Git alert for when you are not on the "main" branch
+  public static Alert gitMainBranchAlert =
+      new Alert(
+          "You are not on the \"main\" branch. Please merge your changes with the \"main\" branch as soon as possible.",
+          AlertType.kWarning);
+
+  // Git alert for when you are on an event branch
+  public static Alert gitEventBranchAlert =
+      new Alert(
+          "You are on an \"event\" branch. Please test any new code on a practice field, and merge changes into \"main\" when possible.",
+          AlertType.kInfo);
+}


### PR DESCRIPTION
All Gradle builds will output a BuildConstants.java file to refer to specific Git information from the driver station.