### PR TITLE
Fix fourbar controls, hardware

### DIFF
--- a/src/main/java/frc/robot/Configs.java
+++ b/src/main/java/frc/robot/Configs.java
@@ -25,8 +25,8 @@ public final class Configs {
           .pid(FourbarConstants.kP, FourbarConstants.kI, FourbarConstants.kD)
           .outputRange(-1, 1)
           .maxMotion
-          .maxVelocity(800)
-          .maxAcceleration(6000)
+          .maxVelocity(2000)
+          .maxAcceleration(1000)
           .positionMode(MAXMotionPositionMode.kMAXMotionTrapezoidal)
           .allowedClosedLoopError(FourbarConstants.kPositionTolerance);
       FourbarConfig.softLimit

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -98,7 +98,7 @@ public final class Constants {
     public static final int kPositionConversionFactor = 360;
     public static final int kVelocityConversionFactor = 1000;
 
-    public static final double kP = 0;
+    public static final double kP = 0.3;
     public static final double kI = 0;
     public static final double kD = 0;
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -13,14 +13,14 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import frc.robot.Constants.FourbarConstants;
 import frc.robot.Constants.OperatorConstants;
 import frc.robot.commands.AlgaeCommand;
 import frc.robot.commands.CAMcommand;
-import frc.robot.commands.FourBarControl;
 import frc.robot.commands.ShooterCommand;
 import frc.robot.misc.Alerts;
 import frc.robot.subsystems.Algae;
@@ -112,15 +112,7 @@ public class RobotContainer {
 
     algae.setDefaultCommand(new AlgaeCommand(algae));
     shooter.setDefaultCommand(new ShooterCommand(shooter));
-    fourbar.setDefaultCommand(new FourBarControl(fourbar));
     cam.setDefaultCommand(new CAMcommand(cam));
-
-    NamedCommands.registerCommand("ShootCoral", new InstantCommand(() -> shooter.shootCoral()));
-    NamedCommands.registerCommand(
-        "StopShooter", new InstantCommand(() -> shooter.disableShooter()));
-    NamedCommands.registerCommand("L2", new InstantCommand(() -> fourbar.L2()));
-    NamedCommands.registerCommand("L3", new InstantCommand(() -> fourbar.L3()));
-    NamedCommands.registerCommand("L4", new InstantCommand(() -> fourbar.L4()));
 
     configureBindings();
 
@@ -193,6 +185,23 @@ public class RobotContainer {
       driverXbox.back().whileTrue(Commands.none());
       driverXbox.leftBumper().whileTrue(Commands.runOnce(drivebase::lock, drivebase).repeatedly());
       driverXbox.rightBumper().onTrue(Commands.none());
+
+      driverController
+          .button(9)
+          .toggleOnTrue(
+              new RunCommand(() -> fourbar.setTargetPosition(FourbarConstants.L1), fourbar));
+      driverController
+          .button(10)
+          .toggleOnTrue(
+              new RunCommand(() -> fourbar.setTargetPosition(FourbarConstants.L2), fourbar));
+      driverController
+          .button(11)
+          .toggleOnTrue(
+              new RunCommand(() -> fourbar.setTargetPosition(FourbarConstants.L3), fourbar));
+      driverController
+          .button(12)
+          .toggleOnTrue(
+              new RunCommand(() -> fourbar.setTargetPosition(FourbarConstants.L4), fourbar));
     }
   }
 

--- a/src/main/java/frc/robot/commands/FourBarControl.java
+++ b/src/main/java/frc/robot/commands/FourBarControl.java
@@ -30,7 +30,7 @@ public class FourBarControl extends Command {
 
     // Set the speed of the fourbar to the joystick value, clamped to a set max speed
     // Check inversion of the joystick to ensure proper mechanism control
-    m_FourBarSubsystem.setFourbarSpeedClamped(BarJoystick.getX());
+    m_FourBarSubsystem.setFourbarSpeedClamped(-BarJoystick.getY());
     /**
      * This is the old code that was used to control the fourbar, it only serves as a reference for
      * new code an also to showcase how to use the SmartDashboard to display information

--- a/src/main/java/frc/robot/commands/FourBarControl.java
+++ b/src/main/java/frc/robot/commands/FourBarControl.java
@@ -24,39 +24,16 @@ public class FourBarControl extends Command {
 
   @Override
 
-  // Controls for the Algae
-
+  // Controls for the Fourbar
   public void execute() {
 
     // Set the speed of the fourbar to the joystick value, clamped to a set max speed
     // Check inversion of the joystick to ensure proper mechanism control
     m_FourBarSubsystem.setFourbarSpeedClamped(-BarJoystick.getY());
-    /**
-     * This is the old code that was used to control the fourbar, it only serves as a reference for
-     * new code an also to showcase how to use the SmartDashboard to display information
-     * SmartDashboard does not slow down the robot code, so it is safe to use it to display
-     * information instead of using System.out.println()
-     */
-    // if (BarJoystick.getRawButton(1)) {
-    //  m_FourBarSubsystem.UpBar();
-    //  fourbarActivity = "Fourbar Up";
-    // } else if (BarJoystick.getRawButton(2)) {
-    //  m_FourBarSubsystem.DownBar();
-    //  fourbarActivity = "Fourbar Down";
-    // } else if (BarJoystick.getRawButton(9)) {
-    //  m_FourBarSubsystem.L2();
-    //  fourbarActivity = "Fourbar L2";
-    // } else if (BarJoystick.getRawButton(10)) {
-    //  m_FourBarSubsystem.L3();
-    //  fourbarActivity = "Fourbar L3";
-    //  // chagne to 9 maybe in the future
-    // } else if (BarJoystick.getRawButton(11)) {
-    //  m_FourBarSubsystem.L4();
-    //  fourbarActivity = "Fourbar L4";
 
     // Check if the joystick is being moved, if it is, report that the fourbar is moving
-    if (BarJoystick.getX() > 0.1 || BarJoystick.getX() < -0.1) {
-      fourbarActivity = "Fourbar moving at " + BarJoystick.getX();
+    if (BarJoystick.getY() > 0.1 || BarJoystick.getY() < -0.1) {
+      fourbarActivity = "Fourbar moving at " + BarJoystick.getY();
     } else {
       m_FourBarSubsystem.disableFourBar();
       fourbarActivity = "Fourbar Disabled";

--- a/src/main/java/frc/robot/subsystems/FourBar.java
+++ b/src/main/java/frc/robot/subsystems/FourBar.java
@@ -94,10 +94,14 @@ public class FourBar extends SubsystemBase {
   }
 
   // Automatically sets fourbar to score L3
-  public void L3() {}
+  public void L3() {
+    setTargetPosition(FourbarConstants.L3);
+  }
 
   // Automatically set fourbar to score L4
-  public void L4() {}
+  public void L4() {
+    setTargetPosition(FourbarConstants.L4);
+  }
 
   /**
    * Set the speed of the fourbar motor, clamped to the maximum speed.

--- a/src/main/java/frc/robot/subsystems/FourBar.java
+++ b/src/main/java/frc/robot/subsystems/FourBar.java
@@ -13,7 +13,6 @@ import com.revrobotics.spark.SparkLowLevel;
 import com.revrobotics.spark.SparkMax;
 import com.revrobotics.spark.config.SparkMaxConfig;
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Configs;
@@ -26,7 +25,7 @@ public class FourBar extends SubsystemBase {
 
   private SparkClosedLoopController fourbar;
 
-  private DutyCycleEncoder shaftEncoder = new DutyCycleEncoder(MechanismConstants.FourbarEncoder);
+  private RelativeEncoder shaftEncoder = FourbarMotor.getEncoder();
 
   private SparkClosedLoopController p_fourbar;
 
@@ -49,7 +48,7 @@ public class FourBar extends SubsystemBase {
 
     e_fourbar = FourbarMotor.getEncoder();
 
-    e_fourbar.setPosition(shaftEncoder.get());
+    e_fourbar.setPosition(0);
   }
 
   public boolean atTargetPosition() {
@@ -62,6 +61,7 @@ public class FourBar extends SubsystemBase {
 
   public void setTargetPosition(double setpoint) {
     m_setpoint = setpoint;
+    moveToSetpoint();
   }
 
   private void moveToSetpoint() {
@@ -83,26 +83,6 @@ public class FourBar extends SubsystemBase {
     FourbarMotor.set(0);
   }
 
-  // Automatically sets fourbar to deafault position to score L1
-  public void L1() {
-    setTargetPosition(FourbarConstants.L1);
-  }
-
-  // Automatically sets fourbar to score L2
-  public void L2() {
-    setTargetPosition(FourbarConstants.L2);
-  }
-
-  // Automatically sets fourbar to score L3
-  public void L3() {
-    setTargetPosition(FourbarConstants.L3);
-  }
-
-  // Automatically set fourbar to score L4
-  public void L4() {
-    setTargetPosition(FourbarConstants.L4);
-  }
-
   /**
    * Set the speed of the fourbar motor, clamped to the maximum speed.
    *
@@ -113,14 +93,22 @@ public class FourBar extends SubsystemBase {
         MathUtil.clamp(speed, -MechanismConstants.FourBarSpeed, MechanismConstants.FourBarSpeed));
   }
 
+  /**
+   * Set the speed of the fourbar with a deadband.
+   *
+   * @param speed Speed to set the fourbar motor to
+   */
+  public void setFourbarSpeedWithDeadband(double speed) {
+    FourbarMotor.set(MathUtil.applyDeadband(speed, 0.025, MechanismConstants.FourBarSpeed));
+  }
+
   @Override
   public void periodic() { // This method will be called once per scheduler run
     SmartDashboard.putNumber("Fourbar/Motor Speed", FourbarMotor.get());
     SmartDashboard.putNumber("Fourbar/Motor Position", e_fourbar.getPosition());
     SmartDashboard.putNumber("Fourbar/Motor Velocity", e_fourbar.getVelocity());
     SmartDashboard.putNumber("Fourbar/Setpoint", m_setpoint);
-    SmartDashboard.putNumber("Fourbar/Shaft Position", shaftEncoder.get());
+    SmartDashboard.putNumber("Fourbar/Shaft Position", shaftEncoder.getPosition());
     SmartDashboard.putBoolean("Fourbar/At Target", atTargetPosition());
-    moveToSetpoint();
   }
 }


### PR DESCRIPTION
Fix orientation of fourbar control from x-axis to y-axis.

Add missing levels for fourbar placement.

Adjusted max velocity and acceleration in FourbarConfig for a baseline. Requires further tuning.

Modified kP value in Constants for a baseline. Requires further tuning.

Refactored RobotContainer to use RunCommand for Fourbar control as previous commands were not great.

Updated FourBar subsystem to use RelativeEncoder and added deadband handling for motor speed.